### PR TITLE
Use linker-fix-3ds via dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,8 @@ edition = "2018"
 crate-type = ["lib", "staticlib"]
 name = "ctru"
 
-[dependencies.libc]
-path = "../libc"
-
-[dependencies.bitflags]
-version = "1.0.0"
-
-[dependencies.widestring]
-version = "0.2.2"
+[dependencies]
+libc = { git = "https://github.com/Meziu/libc.git" }
+linker-fix-3ds = { git = "https://github.com/Meziu/rust-linker-fix-3ds.git" }
+bitflags = "1.0.0"
+widestring = "0.2.2"

--- a/build.rs
+++ b/build.rs
@@ -2,16 +2,21 @@ use std::env;
 
 fn main() {
     let dkp_path = env::var("DEVKITPRO").unwrap();
-        
+
     println!("cargo:rustc-link-lib=static=ctru");
     println!("cargo:rustc-link-lib=static=gcc");
     println!("cargo:rustc-link-lib=static=sysbase");
     println!("cargo:rustc-link-lib=static=c");
     println!("cargo:rustc-link-lib=static=pthread_3ds");
-    println!("cargo:rustc-link-lib=static=linker_fix_3ds");
-    
+
     println!("cargo:rustc-link-search=native=.");
     println!("cargo:rustc-link-search=native={}/libctru/lib", dkp_path);
-    println!("cargo:rustc-link-search=native={}/devkitARM/arm-none-eabi/lib/armv6k/fpu", dkp_path);
-    println!("cargo:rustc-link-search=native={}/devkitARM/lib/gcc/arm-none-eabi/11.1.0/armv6k/fpu", dkp_path);
+    println!(
+        "cargo:rustc-link-search=native={}/devkitARM/arm-none-eabi/lib/armv6k/fpu",
+        dkp_path
+    );
+    println!(
+        "cargo:rustc-link-search=native={}/devkitARM/lib/gcc/arm-none-eabi/11.1.0/armv6k/fpu",
+        dkp_path
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,24 @@
 #![crate_type = "rlib"]
 #![crate_name = "ctru"]
-
 #![feature(rustc_private)]
 
 #[macro_use]
 extern crate bitflags;
-extern crate libc;
-extern crate widestring;
 extern crate core;
+extern crate libc;
+extern crate linker_fix_3ds;
+extern crate widestring;
 
 pub mod applets;
 pub mod console;
 pub mod error;
-pub mod srv;
 pub mod gfx;
-pub mod services;
-pub mod sdmc;
-pub mod thread;
 pub mod raw;
+pub mod sdmc;
+pub mod services;
+pub mod srv;
+pub mod thread;
 
-pub use srv::Srv;
 pub use gfx::Gfx;
 pub use sdmc::Sdmc;
+pub use srv::Srv;


### PR DESCRIPTION
This avoids pulling in a binary blob (liblinker_fix_3ds.a). Related to #2.

Need to merge https://github.com/Meziu/rust-linker-fix-3ds/pull/3 first though, so it can be used as a dependency.

I'm trying to do this same change with the pthread library, but I'm running into some missing symbols when I switch to the dependency instead of binary static lib.

Also includes some automatic rustfmt changes.