### PR TITLE
Link pthread-3ds via Cargo instead of static lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ name = "ctru"
 [dependencies]
 libc = { git = "https://github.com/Meziu/libc.git" }
 linker-fix-3ds = { git = "https://github.com/Meziu/rust-linker-fix-3ds.git" }
+pthread-3ds = { git = "https://github.com/Meziu/pthread-3ds.git" }
 bitflags = "1.0.0"
 widestring = "0.2.2"

--- a/build.rs
+++ b/build.rs
@@ -2,14 +2,11 @@ use std::env;
 
 fn main() {
     let dkp_path = env::var("DEVKITPRO").unwrap();
-    
-    if let Ok(_) = env::var("DEBUG") {
+
+    if env::var("DEBUG").is_ok() {
         println!("cargo:rustc-link-lib=static=ctrud");
     } else {
         println!("cargo:rustc-link-lib=static=ctru");
     }
     println!("cargo:rustc-link-search=native={}/libctru/lib", dkp_path);
-    
-    println!("cargo:rustc-link-search=native=.");
-    println!("cargo:rustc-link-lib=static=pthread_3ds");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,17 @@
 #![crate_type = "rlib"]
 #![crate_name = "ctru"]
-#![feature(rustc_private)]
 
 #[macro_use]
 extern crate bitflags;
-extern crate core;
-extern crate libc;
-extern crate linker_fix_3ds;
-extern crate widestring;
+
+/// Call this somewhere to force Rust to link some required crates
+/// (ex. pthread-3ds). The call doesn't need to execute, just exist.
+///
+/// See https://github.com/rust-lang/rust/issues/47384
+pub fn init() {
+    linker_fix_3ds::init();
+    pthread_3ds::init();
+}
 
 pub mod applets;
 pub mod console;


### PR DESCRIPTION
This fixes the panic issue (not calling `panic_count::increase`) as well as the missing debug info. The static lib contained a second copy of the rust std, which caused these issues.

Rustc bug causing the init workaround: https://github.com/rust-lang/rust/issues/47384

Also fixed up and simplified build.rs and lib.rs.

Fixes #2 