### PR TITLE
Update to Rust 2021 edition, plus clippy and rustfmt fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target
 Cargo.lock
 
+.idea/
+

--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -4,6 +4,7 @@ description = "A safe wrapper around smealum's ctrulib."
 license = "https://en.wikipedia.org/wiki/Zlib_License"
 name = "ctru-rs"
 version = "0.7.1"
+edition = "2018"
 
 [lib]
 crate-type = ["rlib"]

--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -4,7 +4,7 @@ description = "A safe wrapper around smealum's ctrulib."
 license = "https://en.wikipedia.org/wiki/Zlib_License"
 name = "ctru-rs"
 version = "0.7.1"
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["rlib"]

--- a/ctru-rs/examples/buttons.rs
+++ b/ctru-rs/examples/buttons.rs
@@ -1,7 +1,5 @@
-extern crate ctru;
-
-use ctru::gfx::Gfx;
 use ctru::console::Console;
+use ctru::gfx::Gfx;
 use ctru::services::apt::Apt;
 use ctru::services::hid::{Hid, KeyPad};
 
@@ -29,7 +27,6 @@ fn main() {
         // We only want to print when the keys we're holding now are different
         // from what they were on the previous frame
         if keys != old_keys {
-
             // Clear the screen
             console.clear();
 
@@ -62,7 +59,7 @@ fn main() {
             }
             if keys.intersects(KeyPad::KEY_START) {
                 println!("See ya!");
-                break
+                break;
             }
         }
 

--- a/ctru-rs/examples/gfx_wide_mode.rs
+++ b/ctru-rs/examples/gfx_wide_mode.rs
@@ -1,10 +1,10 @@
 extern crate ctru;
 
 use ctru::console::Console;
-use ctru::Gfx;
 use ctru::gfx::Screen;
-use ctru::services::{Apt, Hid};
 use ctru::services::hid::KeyPad;
+use ctru::services::{Apt, Hid};
+use ctru::Gfx;
 
 fn main() {
     ctru::init();
@@ -19,7 +19,7 @@ fn main() {
         hid.scan_input();
 
         if hid.keys_down().contains(KeyPad::KEY_START) {
-            break
+            break;
         }
 
         if hid.keys_down().contains(KeyPad::KEY_A) {

--- a/ctru-rs/examples/hello-both-screens.rs
+++ b/ctru-rs/examples/hello-both-screens.rs
@@ -1,7 +1,5 @@
-extern crate ctru;
-
-use ctru::gfx::{Gfx, Screen};
 use ctru::console::Console;
+use ctru::gfx::{Gfx, Screen};
 use ctru::services::apt::Apt;
 use ctru::services::hid::{Hid, KeyPad};
 

--- a/ctru-rs/examples/hello-world.rs
+++ b/ctru-rs/examples/hello-world.rs
@@ -1,7 +1,5 @@
-extern crate ctru;
-
-use ctru::gfx::Gfx;
 use ctru::console::Console;
+use ctru::gfx::Gfx;
 use ctru::services::apt::Apt;
 use ctru::services::hid::{Hid, KeyPad};
 
@@ -36,7 +34,6 @@ fn main() {
 
     // Main application loop.
     while apt.main_loop() {
-
         // Flushes and swaps the framebuffers when double-buffering
         // is enabled
         gfx.flush_buffers();

--- a/ctru-rs/examples/software-keyboard.rs
+++ b/ctru-rs/examples/software-keyboard.rs
@@ -1,10 +1,8 @@
-extern crate ctru;
-
-use ctru::gfx::Gfx;
+use ctru::applets::swkbd::{Button, Swkbd};
 use ctru::console::Console;
+use ctru::gfx::Gfx;
 use ctru::services::apt::Apt;
 use ctru::services::hid::{Hid, KeyPad};
-use ctru::applets::swkbd::{Swkbd, Button};
 
 fn main() {
     ctru::init();
@@ -34,10 +32,10 @@ fn main() {
             // Raise the software keyboard. You can perform different actions depending on which
             // software button the user pressed
             match keyboard.get_utf8(&mut text) {
-                Ok(Button::Right)   => println!("You entered: {}", text),
-                Ok(Button::Left)    => println!("Cancelled"),
-                Ok(Button::Middle)  => println!("How did you even press this?"),
-                Err(_)              => println!("Oh noes, an error happened!"),
+                Ok(Button::Right) => println!("You entered: {}", text),
+                Ok(Button::Left) => println!("Cancelled"),
+                Ok(Button::Middle) => println!("How did you even press this?"),
+                Err(_) => println!("Oh noes, an error happened!"),
             }
         }
 

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -1,12 +1,10 @@
+use ctru_sys::{
+    self, swkbdInit, swkbdInputText, swkbdSetButton, swkbdSetFeatures, swkbdSetHintText, SwkbdState,
+};
+use libc;
 use std::convert::TryInto;
 use std::iter::once;
 use std::str;
-
-use libctru::{
-    self, swkbdInit, swkbdInputText, swkbdSetButton, swkbdSetFeatures, swkbdSetHintText, SwkbdState,
-};
-
-use libc;
 
 /// An instance of the software keyboard.
 pub struct Swkbd {
@@ -133,10 +131,10 @@ impl Swkbd {
                 buf.as_mut_ptr(),
                 buf.len().try_into().unwrap(),
             ) {
-                libctru::SWKBD_BUTTON_NONE => Err(self.parse_swkbd_error()),
-                libctru::SWKBD_BUTTON_LEFT => Ok(Button::Left),
-                libctru::SWKBD_BUTTON_MIDDLE => Ok(Button::Middle),
-                libctru::SWKBD_BUTTON_RIGHT => Ok(Button::Right),
+                ctru_sys::SWKBD_BUTTON_NONE => Err(self.parse_swkbd_error()),
+                ctru_sys::SWKBD_BUTTON_LEFT => Ok(Button::Left),
+                ctru_sys::SWKBD_BUTTON_MIDDLE => Ok(Button::Middle),
+                ctru_sys::SWKBD_BUTTON_RIGHT => Ok(Button::Right),
                 _ => unreachable!(),
             }
         }
@@ -198,14 +196,14 @@ impl Swkbd {
 
     fn parse_swkbd_error(&self) -> Error {
         match self.state.result {
-            libctru::SWKBD_INVALID_INPUT => Error::InvalidInput,
-            libctru::SWKBD_OUTOFMEM => Error::OutOfMem,
-            libctru::SWKBD_HOMEPRESSED => Error::HomePressed,
-            libctru::SWKBD_RESETPRESSED => Error::ResetPressed,
-            libctru::SWKBD_POWERPRESSED => Error::PowerPressed,
-            libctru::SWKBD_PARENTAL_OK => Error::ParentalOk,
-            libctru::SWKBD_PARENTAL_FAIL => Error::ParentalFail,
-            libctru::SWKBD_BANNED_INPUT => Error::BannedInput,
+            ctru_sys::SWKBD_INVALID_INPUT => Error::InvalidInput,
+            ctru_sys::SWKBD_OUTOFMEM => Error::OutOfMem,
+            ctru_sys::SWKBD_HOMEPRESSED => Error::HomePressed,
+            ctru_sys::SWKBD_RESETPRESSED => Error::ResetPressed,
+            ctru_sys::SWKBD_POWERPRESSED => Error::PowerPressed,
+            ctru_sys::SWKBD_PARENTAL_OK => Error::ParentalOk,
+            ctru_sys::SWKBD_PARENTAL_FAIL => Error::ParentalFail,
+            ctru_sys::SWKBD_BANNED_INPUT => Error::BannedInput,
             _ => unreachable!(),
         }
     }

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -1,3 +1,4 @@
+use bitflags::bitflags;
 use ctru_sys::{
     self, swkbdInit, swkbdInputText, swkbdSetButton, swkbdSetFeatures, swkbdSetHintText, SwkbdState,
 };

--- a/ctru-rs/src/console.rs
+++ b/ctru-rs/src/console.rs
@@ -1,8 +1,8 @@
 use std::default::Default;
 
-use libctru::{consoleClear, consoleInit, consoleSelect, consoleSetWindow, PrintConsole};
+use ctru_sys::{consoleClear, consoleInit, consoleSelect, consoleSetWindow, PrintConsole};
 
-use gfx::Screen;
+use crate::gfx::Screen;
 
 pub struct Console {
     context: Box<PrintConsole>,

--- a/ctru-rs/src/console.rs
+++ b/ctru-rs/src/console.rs
@@ -37,6 +37,7 @@ impl Console {
     /// The first two arguments are the desired coordinates of the top-left corner
     /// of the console, and the second pair is the new width and height
     ///
+    /// # Safety
     /// This function is unsafe because it does not validate that the input will produce
     /// a console that actually fits on the screen
     pub unsafe fn set_window(&mut self, x: i32, y: i32, width: i32, height: i32) {

--- a/ctru-rs/src/gfx.rs
+++ b/ctru-rs/src/gfx.rs
@@ -3,11 +3,11 @@
 use std::default::Default;
 use std::ops::Drop;
 
-use services::gspgpu::{self, FramebufferFormat};
+use crate::services::gspgpu::{self, FramebufferFormat};
 
 /// A handle to libctru's gfx module. This module is a wrapper around the GSPGPU service that
 /// provides helper functions and utilities for software rendering.
-/// 
+///
 /// The service exits when this struct is dropped.
 pub struct Gfx(());
 
@@ -37,75 +37,75 @@ impl Gfx {
     ///
     /// Use `Gfx::default()` instead of this function to initialize the module with default parameters
     pub fn new(
-        top_fb_fmt: FramebufferFormat, bottom_fb_fmt: FramebufferFormat, use_vram_buffers: bool) -> Self {
-        unsafe { ::libctru::gfxInit(top_fb_fmt.into(), bottom_fb_fmt.into(), use_vram_buffers); }
+        top_fb_fmt: FramebufferFormat,
+        bottom_fb_fmt: FramebufferFormat,
+        use_vram_buffers: bool,
+    ) -> Self {
+        unsafe {
+            ctru_sys::gfxInit(top_fb_fmt.into(), bottom_fb_fmt.into(), use_vram_buffers);
+        }
         Gfx(())
     }
 
     /// Enable or disable the 3D stereoscopic effect
     pub fn set_3d_enabled(&self, enabled: bool) {
-        unsafe {
-            ::libctru::gfxSet3D(enabled)
-        }
+        unsafe { ctru_sys::gfxSet3D(enabled) }
     }
 
     /// Enable or disable the wide screen mode (top screen).
     ///
     /// This only works when 3D is disabled.
     pub fn set_wide_mode(&self, enabled: bool) {
-        unsafe { libctru::gfxSetWide(enabled) };
+        unsafe { ctru_sys::gfxSetWide(enabled) };
     }
 
     /// Get the status of wide screen mode.
     pub fn get_wide_mode(&self) -> bool {
-        unsafe { libctru::gfxIsWide() }
+        unsafe { ctru_sys::gfxIsWide() }
     }
 
     /// Sets whether to use double buffering. Enabled by default.
-    /// 
+    ///
     /// Note that even when double buffering is disabled, one should still use the `swap_buffers`
     /// method on each frame to keep the gsp configuration up to date
     pub fn set_double_buffering(&self, screen: Screen, enabled: bool) {
-        unsafe {
-            ::libctru::gfxSetDoubleBuffering(screen.into(), enabled)
-        }
+        unsafe { ctru_sys::gfxSetDoubleBuffering(screen.into(), enabled) }
     }
 
     /// Flushes the current framebuffers
     pub fn flush_buffers(&self) {
-        unsafe { ::libctru::gfxFlushBuffers() };
+        unsafe { ctru_sys::gfxFlushBuffers() };
     }
 
     /// Swaps the framebuffers and sets the gsp state
-    /// 
+    ///
     /// Use this function when working with software rendering
     pub fn swap_buffers(&self) {
-        unsafe { ::libctru::gfxSwapBuffers() };
+        unsafe { ctru_sys::gfxSwapBuffers() };
     }
 
     /// Swaps the framebuffers without manipulating the gsp state
     ///
     /// Use this function when working with GPU rendering
     pub fn swap_buffers_gpu(&self) {
-        unsafe { ::libctru::gfxSwapBuffersGpu() };
+        unsafe { ctru_sys::gfxSwapBuffersGpu() };
     }
 
     /// Waits for the vertical blank interrupt
-    /// 
+    ///
     /// Use this to synchronize your application with the refresh rate of the LCD screens
     pub fn wait_for_vblank(&self) {
         gspgpu::wait_for_event(gspgpu::Event::VBlank0, true);
-
     }
 
     /// Gets the framebuffer format for a screen
     pub fn get_framebuffer_format(&self, screen: Screen) -> FramebufferFormat {
-        unsafe { ::libctru::gfxGetScreenFormat(screen.into()).into() }
+        unsafe { ctru_sys::gfxGetScreenFormat(screen.into()).into() }
     }
 
     /// Change the framebuffer format for a screen
     pub fn set_framebuffer_format(&self, screen: Screen, fmt: FramebufferFormat) {
-        unsafe { ::libctru::gfxSetScreenFormat(screen.into(), fmt.into()) }
+        unsafe { ctru_sys::gfxSetScreenFormat(screen.into(), fmt.into()) }
     }
 
     /// Returns a tuple containing a pointer to the specifified framebuffer (as determined by the
@@ -118,46 +118,42 @@ impl Gfx {
         unsafe {
             let mut width: u16 = 0;
             let mut height: u16 = 0;
-            let buf: *mut u8 = ::libctru::gfxGetFramebuffer(
-                                                            screen.into(),
-                                                            side.into(),
-                                                            &mut width,
-                                                            &mut height,
-                                                            );
+            let buf: *mut u8 =
+                ctru_sys::gfxGetFramebuffer(screen.into(), side.into(), &mut width, &mut height);
             (buf, width, height)
         }
     }
 }
 
-impl From<Screen> for ::libctru::gfxScreen_t {
-    fn from(g: Screen) -> ::libctru::gfxScreen_t {
+impl From<Screen> for ctru_sys::gfxScreen_t {
+    fn from(g: Screen) -> ctru_sys::gfxScreen_t {
         use self::Screen::*;
         match g {
-            Top => ::libctru::GFX_TOP,
-            Bottom => ::libctru::GFX_BOTTOM,
+            Top => ctru_sys::GFX_TOP,
+            Bottom => ctru_sys::GFX_BOTTOM,
         }
     }
 }
 
-impl From<Side> for ::libctru::gfx3dSide_t {
-    fn from(s: Side) -> ::libctru::gfx3dSide_t {
+impl From<Side> for ctru_sys::gfx3dSide_t {
+    fn from(s: Side) -> ctru_sys::gfx3dSide_t {
         use self::Side::*;
         match s {
-            Left => ::libctru::GFX_LEFT,
-            Right => ::libctru::GFX_RIGHT,
+            Left => ctru_sys::GFX_LEFT,
+            Right => ctru_sys::GFX_RIGHT,
         }
     }
 }
 
 impl Default for Gfx {
     fn default() -> Self {
-        unsafe { ::libctru::gfxInitDefault() };
+        unsafe { ctru_sys::gfxInitDefault() };
         Gfx(())
     }
 }
 
 impl Drop for Gfx {
     fn drop(&mut self) {
-        unsafe { ::libctru::gfxExit() };
+        unsafe { ctru_sys::gfxExit() };
     }
 }

--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -1,12 +1,6 @@
 #![crate_type = "rlib"]
 #![crate_name = "ctru"]
 
-#[macro_use]
-extern crate bitflags;
-extern crate ctru_sys;
-extern crate libc;
-extern crate widestring;
-
 /// Call this somewhere to force Rust to link some required crates
 /// This is also a setup for some crate integration only available at runtime
 ///

--- a/ctru-rs/src/lib.rs
+++ b/ctru-rs/src/lib.rs
@@ -3,10 +3,9 @@
 
 #[macro_use]
 extern crate bitflags;
+extern crate ctru_sys;
 extern crate libc;
 extern crate widestring;
-
-extern crate ctru_sys as libctru;
 
 /// Call this somewhere to force Rust to link some required crates
 /// This is also a setup for some crate integration only available at runtime
@@ -20,7 +19,7 @@ pub fn init() {
 
     // Panic Hook setup
     let default_hook = std::panic::take_hook();
-    let new_hook = Box::new( move |info: &PanicInfo| {
+    let new_hook = Box::new(move |info: &PanicInfo| {
         let _bt_console = console::Console::default();
 
         println!("\x1b[1;31m\n--------------------------------------------------");
@@ -47,8 +46,8 @@ pub mod services;
 pub mod srv;
 pub mod thread;
 
-pub use error::{Error, Result};
+pub use crate::error::{Error, Result};
 
-pub use gfx::Gfx;
-pub use sdmc::Sdmc;
-pub use srv::Srv;
+pub use crate::gfx::Gfx;
+pub use crate::sdmc::Sdmc;
+pub use crate::srv::Srv;

--- a/ctru-rs/src/sdmc.rs
+++ b/ctru-rs/src/sdmc.rs
@@ -1,9 +1,9 @@
 pub struct Sdmc(());
 
 impl Sdmc {
-    pub fn init() -> ::Result<Sdmc> {
+    pub fn init() -> crate::Result<Sdmc> {
         unsafe {
-            let r = ::libctru::archiveMountSdmc();
+            let r = ctru_sys::archiveMountSdmc();
             if r < 0 {
                 Err(r.into())
             } else {
@@ -15,6 +15,6 @@ impl Sdmc {
 
 impl Drop for Sdmc {
     fn drop(&mut self) {
-        unsafe { ::libctru::archiveUnmountAll() };
+        unsafe { ctru_sys::archiveUnmountAll() };
     }
 }

--- a/ctru-rs/src/services/apt.rs
+++ b/ctru-rs/src/services/apt.rs
@@ -1,9 +1,9 @@
 pub struct Apt(());
 
 impl Apt {
-    pub fn init() -> ::Result<Apt> {
+    pub fn init() -> crate::Result<Apt> {
         unsafe {
-            let r = ::libctru::aptInit();
+            let r = ctru_sys::aptInit();
             if r < 0 {
                 Err(r.into())
             } else {
@@ -13,25 +13,23 @@ impl Apt {
     }
 
     pub fn main_loop(&self) -> bool {
-        unsafe {
-            ::libctru::aptMainLoop()
-        }
+        unsafe { ctru_sys::aptMainLoop() }
     }
 
-    pub fn set_app_cpu_time_limit(&self, percent: u32) -> ::Result<()> {
+    pub fn set_app_cpu_time_limit(&self, percent: u32) -> crate::Result<()> {
         unsafe {
-           let r = ::libctru::APT_SetAppCpuTimeLimit(percent);
-           if r < 0 {
-               Err(r.into())
-           } else {
-               Ok(())
-           }
+            let r = ctru_sys::APT_SetAppCpuTimeLimit(percent);
+            if r < 0 {
+                Err(r.into())
+            } else {
+                Ok(())
+            }
         }
     }
 }
 
 impl Drop for Apt {
     fn drop(&mut self) {
-        unsafe { ::libctru::aptExit() };
+        unsafe { ctru_sys::aptExit() };
     }
 }

--- a/ctru-rs/src/services/fs.rs
+++ b/ctru-rs/src/services/fs.rs
@@ -272,7 +272,7 @@ pub struct ReadDir<'a> {
 /// filesystem. Each entry can be inspected via methods to learn about the full
 /// path or possibly other metadata.
 pub struct DirEntry<'a> {
-    entry: ::libctru::FS_DirectoryEntry,
+    entry: ctru_sys::FS_DirectoryEntry,
     root: Arc<PathBuf>,
     arch: &'a Archive,
 }
@@ -298,9 +298,9 @@ impl Fs {
     /// ctrulib services are reference counted, so this function may be called
     /// as many times as desired and the service will not exit until all
     /// instances of Fs drop out of scope.
-    pub fn init() -> ::Result<Fs> {
+    pub fn init() -> crate::Result<Fs> {
         unsafe {
-            let r = ::libctru::fsInit();
+            let r = ctru_sys::fsInit();
             if r < 0 {
                 Err(r.into())
             } else {
@@ -310,12 +310,12 @@ impl Fs {
     }
 
     /// Returns a handle to the SDMC (memory card) Archive.
-    pub fn sdmc(&self) -> ::Result<Archive> {
+    pub fn sdmc(&self) -> crate::Result<Archive> {
         unsafe {
             let mut handle = 0;
             let id = ArchiveID::Sdmc;
-            let path = ::libctru::fsMakePath(PathType::Empty.into(), ptr::null() as _);
-            let r = ::libctru::FSUSER_OpenArchive(&mut handle, id.into(), path);
+            let path = ctru_sys::fsMakePath(PathType::Empty.into(), ptr::null() as _);
+            let r = ctru_sys::FSUSER_OpenArchive(&mut handle, id.into(), path);
             if r < 0 {
                 Err(::Error::from(r))
             } else {
@@ -406,7 +406,7 @@ impl File {
     /// This function will return an error if the file is not opened for writing.
     pub fn set_len(&mut self, size: u64) -> IoResult<()> {
         unsafe {
-            let r = ::libctru::FSFILE_SetSize(self.handle, size);
+            let r = ctru_sys::FSFILE_SetSize(self.handle, size);
             if r < 0 {
                 Err(IoError::new(
                     IoErrorKind::PermissionDenied,
@@ -424,7 +424,7 @@ impl File {
         // This is likely to change in the future.
         unsafe {
             let mut size = 0;
-            let r = ::libctru::FSFILE_GetSize(self.handle, &mut size);
+            let r = ctru_sys::FSFILE_GetSize(self.handle, &mut size);
             if r < 0 {
                 Err(IoError::new(
                     IoErrorKind::PermissionDenied,
@@ -442,7 +442,7 @@ impl File {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
         unsafe {
             let mut n_read = 0;
-            let r = ::libctru::FSFILE_Read(
+            let r = ctru_sys::FSFILE_Read(
                 self.handle,
                 &mut n_read,
                 self.offset,
@@ -465,7 +465,7 @@ impl File {
     fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
         unsafe {
             let mut n_written = 0;
-            let r = ::libctru::FSFILE_Write(
+            let r = ctru_sys::FSFILE_Write(
                 self.handle,
                 &mut n_written,
                 self.offset,
@@ -603,8 +603,8 @@ impl OpenOptions {
         unsafe {
             let mut file_handle = 0;
             let path = to_utf16(path);
-            let fs_path = ::libctru::fsMakePath(PathType::UTF16.into(), path.as_ptr() as _);
-            let r = ::libctru::FSUSER_OpenFile(
+            let fs_path = ctru_sys::fsMakePath(PathType::UTF16.into(), path.as_ptr() as _);
+            let r = ctru_sys::FSUSER_OpenFile(
                 &mut file_handle,
                 self.arch_handle,
                 fs_path,
@@ -662,7 +662,7 @@ impl<'a> Iterator for ReadDir<'a> {
             };
             let mut entries_read = 0;
             let entry_count = 1;
-            let r = ::libctru::FSDIR_Read(
+            let r = ctru_sys::FSDIR_Read(
                 self.handle.0,
                 &mut entries_read,
                 entry_count,
@@ -716,8 +716,8 @@ impl<'a> DirEntry<'a> {
 pub fn create_dir<P: AsRef<Path>>(arch: &Archive, path: P) -> IoResult<()> {
     unsafe {
         let path = to_utf16(path.as_ref());
-        let fs_path = ::libctru::fsMakePath(PathType::UTF16.into(), path.as_ptr() as _);
-        let r = ::libctru::FSUSER_CreateDirectory(
+        let fs_path = ctru_sys::fsMakePath(PathType::UTF16.into(), path.as_ptr() as _);
+        let r = ctru_sys::FSUSER_CreateDirectory(
             arch.handle,
             fs_path,
             FsAttribute::FS_ATTRIBUTE_DIRECTORY.bits(),
@@ -778,8 +778,8 @@ pub fn metadata<P: AsRef<Path>>(arch: &Archive, path: P) -> IoResult<Metadata> {
 pub fn remove_dir<P: AsRef<Path>>(arch: &Archive, path: P) -> IoResult<()> {
     unsafe {
         let path = to_utf16(path.as_ref());
-        let fs_path = ::libctru::fsMakePath(PathType::UTF16.into(), path.as_ptr() as _);
-        let r = ::libctru::FSUSER_DeleteDirectory(arch.handle, fs_path);
+        let fs_path = ctru_sys::fsMakePath(PathType::UTF16.into(), path.as_ptr() as _);
+        let r = ctru_sys::FSUSER_DeleteDirectory(arch.handle, fs_path);
         if r < 0 {
             Err(IoError::new(IoErrorKind::Other, ::Error::from(r)))
         } else {
@@ -796,8 +796,8 @@ pub fn remove_dir<P: AsRef<Path>>(arch: &Archive, path: P) -> IoResult<()> {
 pub fn remove_dir_all<P: AsRef<Path>>(arch: &Archive, path: P) -> IoResult<()> {
     unsafe {
         let path = to_utf16(path.as_ref());
-        let fs_path = ::libctru::fsMakePath(PathType::UTF16.into(), path.as_ptr() as _);
-        let r = ::libctru::FSUSER_DeleteDirectoryRecursively(arch.handle, fs_path);
+        let fs_path = ctru_sys::fsMakePath(PathType::UTF16.into(), path.as_ptr() as _);
+        let r = ctru_sys::FSUSER_DeleteDirectoryRecursively(arch.handle, fs_path);
         if r < 0 {
             Err(IoError::new(IoErrorKind::Other, ::Error::from(r)))
         } else {
@@ -822,8 +822,8 @@ pub fn read_dir<P: AsRef<Path>>(arch: &Archive, path: P) -> IoResult<ReadDir> {
         let mut handle = 0;
         let root = Arc::new(path.as_ref().to_path_buf());
         let path = to_utf16(path.as_ref());
-        let fs_path = ::libctru::fsMakePath(PathType::UTF16.into(), path.as_ptr() as _);
-        let r = ::libctru::FSUSER_OpenDirectory(&mut handle, arch.handle, fs_path);
+        let fs_path = ctru_sys::fsMakePath(PathType::UTF16.into(), path.as_ptr() as _);
+        let r = ctru_sys::FSUSER_OpenDirectory(&mut handle, arch.handle, fs_path);
         if r < 0 {
             Err(IoError::new(IoErrorKind::Other, ::Error::from(r)))
         } else {
@@ -848,8 +848,8 @@ pub fn read_dir<P: AsRef<Path>>(arch: &Archive, path: P) -> IoResult<ReadDir> {
 pub fn remove_file<P: AsRef<Path>>(arch: &Archive, path: P) -> IoResult<()> {
     unsafe {
         let path = to_utf16(path.as_ref());
-        let fs_path = ::libctru::fsMakePath(PathType::UTF16.into(), path.as_ptr() as _);
-        let r = ::libctru::FSUSER_DeleteFile(arch.handle, fs_path);
+        let fs_path = ctru_sys::fsMakePath(PathType::UTF16.into(), path.as_ptr() as _);
+        let r = ctru_sys::FSUSER_DeleteFile(arch.handle, fs_path);
         if r < 0 {
             Err(IoError::new(IoErrorKind::Other, ::Error::from(r)))
         } else {
@@ -877,14 +877,14 @@ where
         let from = to_utf16(from.as_ref());
         let to = to_utf16(to.as_ref());
 
-        let fs_from = ::libctru::fsMakePath(PathType::UTF16.into(), from.as_ptr() as _);
-        let fs_to = ::libctru::fsMakePath(PathType::UTF16.into(), to.as_ptr() as _);
+        let fs_from = ctru_sys::fsMakePath(PathType::UTF16.into(), from.as_ptr() as _);
+        let fs_to = ctru_sys::fsMakePath(PathType::UTF16.into(), to.as_ptr() as _);
 
-        let r = ::libctru::FSUSER_RenameFile(arch.handle, fs_from, arch.handle, fs_to);
+        let r = ctru_sys::FSUSER_RenameFile(arch.handle, fs_from, arch.handle, fs_to);
         if r == 0 {
             return Ok(());
         }
-        let r = ::libctru::FSUSER_RenameDirectory(arch.handle, fs_from, arch.handle, fs_to);
+        let r = ctru_sys::FSUSER_RenameDirectory(arch.handle, fs_from, arch.handle, fs_to);
         if r == 0 {
             return Ok(());
         }
@@ -998,7 +998,7 @@ impl Seek for File {
 impl Drop for Fs {
     fn drop(&mut self) {
         unsafe {
-            ::libctru::fsExit();
+            ctru_sys::fsExit();
         }
     }
 }
@@ -1006,7 +1006,7 @@ impl Drop for Fs {
 impl Drop for Archive {
     fn drop(&mut self) {
         unsafe {
-            ::libctru::FSUSER_CloseArchive(self.handle);
+            ctru_sys::FSUSER_CloseArchive(self.handle);
         }
     }
 }
@@ -1014,7 +1014,7 @@ impl Drop for Archive {
 impl Drop for File {
     fn drop(&mut self) {
         unsafe {
-            ::libctru::FSFILE_Close(self.handle);
+            ctru_sys::FSFILE_Close(self.handle);
         }
     }
 }
@@ -1022,50 +1022,50 @@ impl Drop for File {
 impl Drop for Dir {
     fn drop(&mut self) {
         unsafe {
-            ::libctru::FSDIR_Close(self.0);
+            ctru_sys::FSDIR_Close(self.0);
         }
     }
 }
 
-impl From<PathType> for ::libctru::FS_PathType {
+impl From<PathType> for ctru_sys::FS_PathType {
     fn from(p: PathType) -> Self {
         use self::PathType::*;
         match p {
-            Invalid => ::libctru::PATH_INVALID,
-            Empty => ::libctru::PATH_EMPTY,
-            Binary => ::libctru::PATH_BINARY,
-            ASCII => ::libctru::PATH_ASCII,
-            UTF16 => ::libctru::PATH_UTF16,
+            Invalid => ctru_sys::PATH_INVALID,
+            Empty => ctru_sys::PATH_EMPTY,
+            Binary => ctru_sys::PATH_BINARY,
+            ASCII => ctru_sys::PATH_ASCII,
+            UTF16 => ctru_sys::PATH_UTF16,
         }
     }
 }
 
-impl From<ArchiveID> for ::libctru::FS_ArchiveID {
+impl From<ArchiveID> for ctru_sys::FS_ArchiveID {
     fn from(a: ArchiveID) -> Self {
         use self::ArchiveID::*;
         match a {
-            RomFS => ::libctru::ARCHIVE_ROMFS,
-            Savedata => ::libctru::ARCHIVE_SAVEDATA,
-            Extdata => ::libctru::ARCHIVE_EXTDATA,
-            SharedExtdata => ::libctru::ARCHIVE_SHARED_EXTDATA,
-            SystemSavedata => ::libctru::ARCHIVE_SYSTEM_SAVEDATA,
-            Sdmc => ::libctru::ARCHIVE_SDMC,
-            SdmcWriteOnly => ::libctru::ARCHIVE_SDMC_WRITE_ONLY,
-            BossExtdata => ::libctru::ARCHIVE_BOSS_EXTDATA,
-            CardSpiFS => ::libctru::ARCHIVE_CARD_SPIFS,
-            ExtDataAndBossExtdata => ::libctru::ARCHIVE_EXTDATA_AND_BOSS_EXTDATA,
-            SystemSaveData2 => ::libctru::ARCHIVE_SYSTEM_SAVEDATA2,
-            NandRW => ::libctru::ARCHIVE_NAND_RW,
-            NandRO => ::libctru::ARCHIVE_NAND_RO,
-            NandROWriteAccess => ::libctru::ARCHIVE_NAND_RO_WRITE_ACCESS,
-            SaveDataAndContent => ::libctru::ARCHIVE_SAVEDATA_AND_CONTENT,
-            SaveDataAndContent2 => ::libctru::ARCHIVE_SAVEDATA_AND_CONTENT2,
-            NandCtrFS => ::libctru::ARCHIVE_NAND_CTR_FS,
-            TwlPhoto => ::libctru::ARCHIVE_TWL_PHOTO,
-            NandTwlFS => ::libctru::ARCHIVE_NAND_TWL_FS,
-            GameCardSavedata => ::libctru::ARCHIVE_GAMECARD_SAVEDATA,
-            UserSavedata => ::libctru::ARCHIVE_USER_SAVEDATA,
-            DemoSavedata => ::libctru::ARCHIVE_DEMO_SAVEDATA,
+            RomFS => ctru_sys::ARCHIVE_ROMFS,
+            Savedata => ctru_sys::ARCHIVE_SAVEDATA,
+            Extdata => ctru_sys::ARCHIVE_EXTDATA,
+            SharedExtdata => ctru_sys::ARCHIVE_SHARED_EXTDATA,
+            SystemSavedata => ctru_sys::ARCHIVE_SYSTEM_SAVEDATA,
+            Sdmc => ctru_sys::ARCHIVE_SDMC,
+            SdmcWriteOnly => ctru_sys::ARCHIVE_SDMC_WRITE_ONLY,
+            BossExtdata => ctru_sys::ARCHIVE_BOSS_EXTDATA,
+            CardSpiFS => ctru_sys::ARCHIVE_CARD_SPIFS,
+            ExtDataAndBossExtdata => ctru_sys::ARCHIVE_EXTDATA_AND_BOSS_EXTDATA,
+            SystemSaveData2 => ctru_sys::ARCHIVE_SYSTEM_SAVEDATA2,
+            NandRW => ctru_sys::ARCHIVE_NAND_RW,
+            NandRO => ctru_sys::ARCHIVE_NAND_RO,
+            NandROWriteAccess => ctru_sys::ARCHIVE_NAND_RO_WRITE_ACCESS,
+            SaveDataAndContent => ctru_sys::ARCHIVE_SAVEDATA_AND_CONTENT,
+            SaveDataAndContent2 => ctru_sys::ARCHIVE_SAVEDATA_AND_CONTENT2,
+            NandCtrFS => ctru_sys::ARCHIVE_NAND_CTR_FS,
+            TwlPhoto => ctru_sys::ARCHIVE_TWL_PHOTO,
+            NandTwlFS => ctru_sys::ARCHIVE_NAND_TWL_FS,
+            GameCardSavedata => ctru_sys::ARCHIVE_GAMECARD_SAVEDATA,
+            UserSavedata => ctru_sys::ARCHIVE_USER_SAVEDATA,
+            DemoSavedata => ctru_sys::ARCHIVE_DEMO_SAVEDATA,
         }
     }
 }

--- a/ctru-rs/src/services/fs.rs
+++ b/ctru-rs/src/services/fs.rs
@@ -317,7 +317,7 @@ impl Fs {
             let path = ctru_sys::fsMakePath(PathType::Empty.into(), ptr::null() as _);
             let r = ctru_sys::FSUSER_OpenArchive(&mut handle, id.into(), path);
             if r < 0 {
-                Err(::Error::from(r))
+                Err(crate::Error::from(r))
             } else {
                 Ok(Archive {
                     handle: handle,
@@ -410,7 +410,7 @@ impl File {
             if r < 0 {
                 Err(IoError::new(
                     IoErrorKind::PermissionDenied,
-                    ::Error::from(r),
+                    crate::Error::from(r),
                 ))
             } else {
                 Ok(())
@@ -428,7 +428,7 @@ impl File {
             if r < 0 {
                 Err(IoError::new(
                     IoErrorKind::PermissionDenied,
-                    ::Error::from(r),
+                    crate::Error::from(r),
                 ))
             } else {
                 Ok(Metadata {
@@ -451,7 +451,7 @@ impl File {
             );
             self.offset += n_read as u64;
             if r < 0 {
-                Err(IoError::new(IoErrorKind::Other, ::Error::from(r)))
+                Err(IoError::new(IoErrorKind::Other, crate::Error::from(r)))
             } else {
                 Ok(n_read as usize)
             }
@@ -475,7 +475,7 @@ impl File {
             );
             self.offset += n_written as u64;
             if r < 0 {
-                Err(IoError::new(IoErrorKind::Other, ::Error::from(r)))
+                Err(IoError::new(IoErrorKind::Other, crate::Error::from(r)))
             } else {
                 Ok(n_written as usize)
             }
@@ -612,7 +612,7 @@ impl OpenOptions {
                 0,
             );
             if r < 0 {
-                return Err(IoError::new(IoErrorKind::Other, ::Error::from(r)));
+                return Err(IoError::new(IoErrorKind::Other, crate::Error::from(r)));
             }
 
             let mut file = File {
@@ -670,7 +670,7 @@ impl<'a> Iterator for ReadDir<'a> {
             );
 
             if r < 0 {
-                return Some(Err(IoError::new(IoErrorKind::Other, ::Error::from(r))));
+                return Some(Err(IoError::new(IoErrorKind::Other, crate::Error::from(r))));
             }
             if entries_read != entry_count {
                 return None;
@@ -723,7 +723,7 @@ pub fn create_dir<P: AsRef<Path>>(arch: &Archive, path: P) -> IoResult<()> {
             FsAttribute::FS_ATTRIBUTE_DIRECTORY.bits(),
         );
         if r < 0 {
-            Err(IoError::new(IoErrorKind::Other, ::Error::from(r)))
+            Err(IoError::new(IoErrorKind::Other, crate::Error::from(r)))
         } else {
             Ok(())
         }
@@ -781,7 +781,7 @@ pub fn remove_dir<P: AsRef<Path>>(arch: &Archive, path: P) -> IoResult<()> {
         let fs_path = ctru_sys::fsMakePath(PathType::UTF16.into(), path.as_ptr() as _);
         let r = ctru_sys::FSUSER_DeleteDirectory(arch.handle, fs_path);
         if r < 0 {
-            Err(IoError::new(IoErrorKind::Other, ::Error::from(r)))
+            Err(IoError::new(IoErrorKind::Other, crate::Error::from(r)))
         } else {
             Ok(())
         }
@@ -799,7 +799,7 @@ pub fn remove_dir_all<P: AsRef<Path>>(arch: &Archive, path: P) -> IoResult<()> {
         let fs_path = ctru_sys::fsMakePath(PathType::UTF16.into(), path.as_ptr() as _);
         let r = ctru_sys::FSUSER_DeleteDirectoryRecursively(arch.handle, fs_path);
         if r < 0 {
-            Err(IoError::new(IoErrorKind::Other, ::Error::from(r)))
+            Err(IoError::new(IoErrorKind::Other, crate::Error::from(r)))
         } else {
             Ok(())
         }
@@ -825,7 +825,7 @@ pub fn read_dir<P: AsRef<Path>>(arch: &Archive, path: P) -> IoResult<ReadDir> {
         let fs_path = ctru_sys::fsMakePath(PathType::UTF16.into(), path.as_ptr() as _);
         let r = ctru_sys::FSUSER_OpenDirectory(&mut handle, arch.handle, fs_path);
         if r < 0 {
-            Err(IoError::new(IoErrorKind::Other, ::Error::from(r)))
+            Err(IoError::new(IoErrorKind::Other, crate::Error::from(r)))
         } else {
             Ok(ReadDir {
                 handle: Dir(handle),
@@ -851,7 +851,7 @@ pub fn remove_file<P: AsRef<Path>>(arch: &Archive, path: P) -> IoResult<()> {
         let fs_path = ctru_sys::fsMakePath(PathType::UTF16.into(), path.as_ptr() as _);
         let r = ctru_sys::FSUSER_DeleteFile(arch.handle, fs_path);
         if r < 0 {
-            Err(IoError::new(IoErrorKind::Other, ::Error::from(r)))
+            Err(IoError::new(IoErrorKind::Other, crate::Error::from(r)))
         } else {
             Ok(())
         }
@@ -888,7 +888,7 @@ where
         if r == 0 {
             return Ok(());
         }
-        Err(IoError::new(IoErrorKind::Other, ::Error::from(r)))
+        Err(IoError::new(IoErrorKind::Other, crate::Error::from(r)))
     }
 }
 

--- a/ctru-rs/src/services/fs.rs
+++ b/ctru-rs/src/services/fs.rs
@@ -3,18 +3,17 @@
 //! This module contains basic methods to manipulate the contents of the 3DS's filesystem.
 //! Only the SD card is currently supported.
 
+use bitflags::bitflags;
+use std::ffi::OsString;
 use std::io::Error as IoError;
 use std::io::ErrorKind as IoErrorKind;
 use std::io::Result as IoResult;
 use std::io::{Read, Seek, SeekFrom, Write};
-
-use std::ffi::OsString;
 use std::mem;
 use std::path::{Path, PathBuf};
 use std::ptr;
 use std::slice;
 use std::sync::Arc;
-
 use widestring::{WideCStr, WideCString};
 
 bitflags! {

--- a/ctru-rs/src/services/fs.rs
+++ b/ctru-rs/src/services/fs.rs
@@ -427,7 +427,10 @@ impl File {
                     crate::Error::from(r),
                 ))
             } else {
-                Ok(Metadata { attributes: 0, size })
+                Ok(Metadata {
+                    attributes: 0,
+                    size,
+                })
             }
         }
     }
@@ -922,10 +925,8 @@ unsafe fn read_to_end_uninitialized(r: &mut dyn Read, buf: &mut Vec<u8>) -> IoRe
             buf.reserve(1);
         }
 
-        let buf_slice = slice::from_raw_parts_mut(
-            buf.as_mut_ptr().add(buf.len()),
-            buf.capacity() - buf.len(),
-        );
+        let buf_slice =
+            slice::from_raw_parts_mut(buf.as_mut_ptr().add(buf.len()), buf.capacity() - buf.len());
 
         match r.read(buf_slice) {
             Ok(0) => {

--- a/ctru-rs/src/services/gspgpu.rs
+++ b/ctru-rs/src/services/gspgpu.rs
@@ -47,48 +47,48 @@ impl FramebufferFormat {
 /// `discard_current` determines whether to discard the current event and wait for the next event
 pub fn wait_for_event(ev: Event, discard_current: bool) {
     unsafe {
-        ::libctru::gspWaitForEvent(ev.into(), discard_current);
+        ctru_sys::gspWaitForEvent(ev.into(), discard_current);
     }
 }
 
-impl From<::libctru::GSPGPU_FramebufferFormat> for FramebufferFormat {
-    fn from(g: ::libctru::GSPGPU_FramebufferFormat) -> Self {
+impl From<ctru_sys::GSPGPU_FramebufferFormat> for FramebufferFormat {
+    fn from(g: ctru_sys::GSPGPU_FramebufferFormat) -> Self {
         use self::FramebufferFormat::*;
         match g {
-            ::libctru::GSP_RGBA8_OES => Rgba8,
-            ::libctru::GSP_BGR8_OES => Bgr8,
-            ::libctru::GSP_RGB565_OES => Rgb565,
-            ::libctru::GSP_RGB5_A1_OES => Rgb5A1,
-            ::libctru::GSP_RGBA4_OES => Rgba4,
+            ctru_sys::GSP_RGBA8_OES => Rgba8,
+            ctru_sys::GSP_BGR8_OES => Bgr8,
+            ctru_sys::GSP_RGB565_OES => Rgb565,
+            ctru_sys::GSP_RGB5_A1_OES => Rgb5A1,
+            ctru_sys::GSP_RGBA4_OES => Rgba4,
             _ => unreachable!(),
         }
     }
 }
 
-impl From<FramebufferFormat> for ::libctru::GSPGPU_FramebufferFormat {
+impl From<FramebufferFormat> for ctru_sys::GSPGPU_FramebufferFormat {
     fn from(g: FramebufferFormat) -> Self {
         use self::FramebufferFormat::*;
         match g {
-            Rgba8 => ::libctru::GSP_RGBA8_OES,
-            Bgr8 => ::libctru::GSP_BGR8_OES,
-            Rgb565 => ::libctru::GSP_RGB565_OES,
-            Rgb5A1 => ::libctru::GSP_RGB5_A1_OES,
-            Rgba4 => ::libctru::GSP_RGBA4_OES,
+            Rgba8 => ctru_sys::GSP_RGBA8_OES,
+            Bgr8 => ctru_sys::GSP_BGR8_OES,
+            Rgb565 => ctru_sys::GSP_RGB565_OES,
+            Rgb5A1 => ctru_sys::GSP_RGB5_A1_OES,
+            Rgba4 => ctru_sys::GSP_RGBA4_OES,
         }
     }
 }
 
-impl From<Event> for ::libctru::GSPGPU_Event {
+impl From<Event> for ctru_sys::GSPGPU_Event {
     fn from(ev: Event) -> Self {
         use self::Event::*;
         match ev {
-            Psc0 => ::libctru::GSPGPU_EVENT_PSC0,
-            Psc1 => ::libctru::GSPGPU_EVENT_PSC1,
-            VBlank0 => ::libctru::GSPGPU_EVENT_VBlank0,
-            VBlank1 => ::libctru::GSPGPU_EVENT_VBlank1,
-            PPF => ::libctru::GSPGPU_EVENT_PPF,
-            P3D => ::libctru::GSPGPU_EVENT_P3D,
-            DMA => ::libctru::GSPGPU_EVENT_DMA,
+            Psc0 => ctru_sys::GSPGPU_EVENT_PSC0,
+            Psc1 => ctru_sys::GSPGPU_EVENT_PSC1,
+            VBlank0 => ctru_sys::GSPGPU_EVENT_VBlank0,
+            VBlank1 => ctru_sys::GSPGPU_EVENT_VBlank1,
+            PPF => ctru_sys::GSPGPU_EVENT_PPF,
+            P3D => ctru_sys::GSPGPU_EVENT_P3D,
+            DMA => ctru_sys::GSPGPU_EVENT_DMA,
         }
     }
 }

--- a/ctru-rs/src/services/hid.rs
+++ b/ctru-rs/src/services/hid.rs
@@ -4,7 +4,7 @@
 //! and circle pad information. It also provides information from the sound volume slider,
 //! the accelerometer, and the gyroscope.
 
-bitflags! {
+bitflags::bitflags! {
     /// A set of flags corresponding to the button and directional pad
     /// inputs on the 3DS
     #[derive(Default)]

--- a/ctru-rs/src/services/hid.rs
+++ b/ctru-rs/src/services/hid.rs
@@ -47,10 +47,10 @@ bitflags! {
 pub struct Hid(());
 
 /// Represents user input to the touchscreen.
-pub struct TouchPosition(::libctru::touchPosition);
+pub struct TouchPosition(ctru_sys::touchPosition);
 
 /// Represents the current position of the 3DS circle pad.
-pub struct CirclePosition(::libctru::circlePosition);
+pub struct CirclePosition(ctru_sys::circlePosition);
 
 /// Initializes the HID service.
 ///
@@ -60,9 +60,9 @@ pub struct CirclePosition(::libctru::circlePosition);
 /// Since this service requires no special or elevated permissions, errors are
 /// rare in practice.
 impl Hid {
-    pub fn init() -> ::Result<Hid> {
+    pub fn init() -> crate::Result<Hid> {
         unsafe {
-            let r = ::libctru::hidInit();
+            let r = ctru_sys::hidInit();
             if r < 0 {
                 Err(r.into())
             } else {
@@ -75,14 +75,14 @@ impl Hid {
     /// frame. This function should be called on every frame when polling
     /// for user input.
     pub fn scan_input(&self) {
-        unsafe { ::libctru::hidScanInput() };
+        unsafe { ctru_sys::hidScanInput() };
     }
 
     /// Returns a bitflag struct representing which buttons have just been pressed
     /// on the current frame (and were not pressed on the previous frame).
     pub fn keys_down(&self) -> KeyPad {
         unsafe {
-            let keys = ::libctru::hidKeysDown();
+            let keys = ctru_sys::hidKeysDown();
             KeyPad::from_bits_truncate(keys)
         }
     }
@@ -91,7 +91,7 @@ impl Hid {
     /// during the current frame.
     pub fn keys_held(&self) -> KeyPad {
         unsafe {
-            let keys = ::libctru::hidKeysHeld();
+            let keys = ctru_sys::hidKeysHeld();
             KeyPad::from_bits_truncate(keys)
         }
     }
@@ -100,7 +100,7 @@ impl Hid {
     /// the current frame.
     pub fn keys_up(&self) -> KeyPad {
         unsafe {
-            let keys = ::libctru::hidKeysUp();
+            let keys = ctru_sys::hidKeysUp();
             KeyPad::from_bits_truncate(keys)
         }
     }
@@ -109,13 +109,13 @@ impl Hid {
 impl TouchPosition {
     /// Create a new TouchPosition instance.
     pub fn new() -> Self {
-        TouchPosition(::libctru::touchPosition { px: 0, py: 0 })
+        TouchPosition(ctru_sys::touchPosition { px: 0, py: 0 })
     }
 
     /// Returns the current touch position in pixels.
     pub fn get(&mut self) -> (u16, u16) {
         unsafe {
-            ::libctru::hidTouchRead(&mut self.0);
+            ctru_sys::hidTouchRead(&mut self.0);
         }
         (self.0.px, self.0.py)
     }
@@ -124,13 +124,13 @@ impl TouchPosition {
 impl CirclePosition {
     /// Create a new CirclePosition instance.
     pub fn new() -> Self {
-        CirclePosition(::libctru::circlePosition { dx: 0, dy: 0 })
+        CirclePosition(ctru_sys::circlePosition { dx: 0, dy: 0 })
     }
 
     /// Returns the current circle pad position in (x, y) form.
     pub fn get(&mut self) -> (i16, i16) {
         unsafe {
-            ::libctru::hidCircleRead(&mut self.0);
+            ctru_sys::hidCircleRead(&mut self.0);
         }
         (self.0.dx, self.0.dy)
     }
@@ -138,6 +138,6 @@ impl CirclePosition {
 
 impl Drop for Hid {
     fn drop(&mut self) {
-        unsafe { ::libctru::hidExit() };
+        unsafe { ctru_sys::hidExit() };
     }
 }

--- a/ctru-rs/src/services/hid.rs
+++ b/ctru-rs/src/services/hid.rs
@@ -106,10 +106,16 @@ impl Hid {
     }
 }
 
+impl Default for TouchPosition {
+    fn default() -> Self {
+        TouchPosition(ctru_sys::touchPosition { px: 0, py: 0 })
+    }
+}
+
 impl TouchPosition {
     /// Create a new TouchPosition instance.
     pub fn new() -> Self {
-        TouchPosition(ctru_sys::touchPosition { px: 0, py: 0 })
+        Self::default()
     }
 
     /// Returns the current touch position in pixels.
@@ -121,10 +127,16 @@ impl TouchPosition {
     }
 }
 
+impl Default for CirclePosition {
+    fn default() -> Self {
+        CirclePosition(ctru_sys::circlePosition { dx: 0, dy: 0 })
+    }
+}
+
 impl CirclePosition {
     /// Create a new CirclePosition instance.
     pub fn new() -> Self {
-        CirclePosition(ctru_sys::circlePosition { dx: 0, dy: 0 })
+        Self::default()
     }
 
     /// Returns the current circle pad position in (x, y) form.

--- a/ctru-rs/src/services/mod.rs
+++ b/ctru-rs/src/services/mod.rs
@@ -1,10 +1,10 @@
 pub mod apt;
 pub mod fs;
-pub mod hid;
 pub mod gspgpu;
+pub mod hid;
 pub mod soc;
 pub mod sslc;
 
-pub use self::hid::Hid;
 pub use self::apt::Apt;
+pub use self::hid::Hid;
 pub use self::sslc::SslC;

--- a/ctru-rs/src/services/soc.rs
+++ b/ctru-rs/src/services/soc.rs
@@ -1,6 +1,6 @@
+use ctru_sys::{socExit, socInit};
+use libc::{free, memalign};
 use std::net::Ipv4Addr;
-use libctru::{socInit, socExit};
-use libc::{memalign, free};
 
 /// Soc service. Initializing this service will enable the use of network sockets and utilities
 /// such as those found in `std::net`. The service will be closed when this struct is is dropped.
@@ -14,7 +14,7 @@ impl Soc {
     /// # Errors
     ///
     /// This function will return an error if the `Soc` service is already initialized
-    pub fn init() -> ::Result<Soc> {
+    pub fn init() -> crate::Result<Soc> {
         Soc::init_with_buffer_size(0x100000)
     }
 
@@ -24,7 +24,7 @@ impl Soc {
     /// # Errors
     ///
     /// This function will return an error if the `Soc` service is already initialized
-    pub fn init_with_buffer_size(num_bytes: usize) -> ::Result<Soc> {
+    pub fn init_with_buffer_size(num_bytes: usize) -> crate::Result<Soc> {
         unsafe {
             let soc_mem = memalign(0x1000, num_bytes) as *mut u32;
 
@@ -33,7 +33,7 @@ impl Soc {
                 free(soc_mem as *mut _);
                 Err(r.into())
             } else {
-                Ok(Soc { soc_mem, })
+                Ok(Soc { soc_mem })
             }
         }
     }

--- a/ctru-rs/src/services/sslc.rs
+++ b/ctru-rs/src/services/sslc.rs
@@ -4,9 +4,9 @@ pub struct SslC(());
 
 impl SslC {
     /// Initialize sslc
-    pub fn init() -> ::Result<Self> {
+    pub fn init() -> crate::Result<Self> {
         unsafe {
-            let r = ::libctru::sslcInit(0);
+            let r = ctru_sys::sslcInit(0);
             if r < 0 {
                 Err(r.into())
             } else {
@@ -16,9 +16,9 @@ impl SslC {
     }
 
     /// Fill `buf` with `buf.len()` random bytes
-    pub fn generate_random_data(&self, buf: &mut [u8]) -> ::Result<()> {
+    pub fn generate_random_data(&self, buf: &mut [u8]) -> crate::Result<()> {
         unsafe {
-            let r = ::libctru::sslcGenerateRandomData(buf.as_ptr() as _, buf.len() as u32);
+            let r = ctru_sys::sslcGenerateRandomData(buf.as_ptr() as _, buf.len() as u32);
             if r < 0 {
                 Err(r.into())
             } else {
@@ -30,6 +30,6 @@ impl SslC {
 
 impl Drop for SslC {
     fn drop(&mut self) {
-        unsafe { ::libctru::sslcExit() };
+        unsafe { ctru_sys::sslcExit() };
     }
 }

--- a/ctru-rs/src/srv.rs
+++ b/ctru-rs/src/srv.rs
@@ -1,9 +1,9 @@
 pub struct Srv(());
 
 impl Srv {
-    pub fn init() -> ::Result<Srv> {
+    pub fn init() -> crate::Result<Srv> {
         unsafe {
-            let r = ::libctru::srvInit();
+            let r = ctru_sys::srvInit();
             if r < 0 {
                 Err(r.into())
             } else {
@@ -15,6 +15,6 @@ impl Srv {
 
 impl Drop for Srv {
     fn drop(&mut self) {
-        unsafe { ::libctru::srvExit() };
+        unsafe { ctru_sys::srvExit() };
     }
 }

--- a/ctru-rs/src/thread.rs
+++ b/ctru-rs/src/thread.rs
@@ -896,7 +896,7 @@ mod imp {
 
     use libc;
 
-    use libctru::{
+    use ctru_sys::{
         svcGetProcessorID, svcGetThreadId, svcGetThreadPriority, svcSleepThread, threadCreate,
         threadDetach, threadFree, threadJoin, Thread as ThreadHandle,
     };
@@ -1009,8 +1009,8 @@ mod imp {
 }
 
 mod thread_info {
+    use crate::thread::Thread;
     use std::cell::RefCell;
-    use thread::Thread;
 
     struct ThreadInfo {
         thread: Thread,

--- a/ctru-sys/Cargo.toml
+++ b/ctru-sys/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 authors = ["Ronald Kinard <furyhunter600@gmail.com>"]
 license = "https://en.wikipedia.org/wiki/Zlib_License"
 links = "ctru"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 libc = { version = "0.2", default-features = false }

--- a/ctru-sys/Cargo.toml
+++ b/ctru-sys/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.4.0"
 authors = ["Ronald Kinard <furyhunter600@gmail.com>"]
 license = "https://en.wikipedia.org/wiki/Zlib_License"
 links = "ctru"
+edition = "2018"
 
 [dependencies]
 libc = { version = "0.2", default-features = false }

--- a/ctru-sys/src/lib.rs
+++ b/ctru-sys/src/lib.rs
@@ -3,6 +3,4 @@
 #![allow(non_snake_case)]
 #![no_std]
 
-extern crate libc;
-
 include!("bindings.rs");

--- a/ctru-sys/src/lib.rs
+++ b/ctru-sys/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![allow(clippy::all)]
 #![no_std]
 
 include!("bindings.rs");


### PR DESCRIPTION
Also removed renaming of `ctru_sys` to `libctru` in `ctru-rs`.