### PR TITLE
Add back Console::drop

### DIFF
--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -12,6 +12,7 @@ name = "ctru"
 
 [dependencies]
 ctru-sys = { path = "../ctru-sys", version = "0.4" }
+const-zero = "0.1.0"
 linker-fix-3ds = { git = "https://github.com/Meziu/rust-linker-fix-3ds.git" }
 pthread-3ds = { git = "https://github.com/Meziu/pthread-3ds.git" }
 libc = { git = "https://github.com/Meziu/libc.git" }

--- a/ctru-rs/src/console.rs
+++ b/ctru-rs/src/console.rs
@@ -53,22 +53,23 @@ impl Default for Console {
 
 impl Drop for Console {
     fn drop(&mut self) {
+        static mut EMPTY_CONSOLE: PrintConsole = unsafe { const_zero::const_zero!(PrintConsole) };
+
         unsafe {
             // Safety: We are about to deallocate the PrintConsole data pointed
             // to by libctru. Without this drop code libctru would have a
             // dangling pointer that it writes to on every print. To prevent
-            // this we replace the console with the default if it was selected.
+            // this we replace the console with an empty one if it was selected.
+            // This is the same state that libctru starts up in, before
+            // initializing a console. Writes to the console will not show up on
+            // the screen, but it won't crash either.
 
-            // Get the current console by replacing it with the default.
-            let default_console = ctru_sys::consoleGetDefault();
-            let current_console = ctru_sys::consoleSelect(default_console);
+            // Get the current console by replacing it with an empty one.
+            let current_console = ctru_sys::consoleSelect(&mut EMPTY_CONSOLE);
 
             if std::ptr::eq(current_console, &*self.context) {
                 // Console dropped while selected. We just replaced it with the
-                // default so make sure it's initialized.
-                if !(*default_console).consoleInitialised {
-                    ctru_sys::consoleInit(Screen::Top.into(), default_console);
-                }
+                // empty console so nothing more to do.
             } else {
                 // Console dropped while a different console was selected. Put back
                 // the console that was selected.

--- a/ctru-rs/src/console.rs
+++ b/ctru-rs/src/console.rs
@@ -50,3 +50,22 @@ impl Default for Console {
         Console::init(Screen::Top)
     }
 }
+
+impl Drop for Console {
+    fn drop(&mut self) {
+        unsafe {
+            // Get the current console by replacing it with the default.
+            let default_console = ctru_sys::consoleGetDefault();
+            let current_console = ctru_sys::consoleSelect(default_console);
+
+            if std::ptr::eq(current_console, &*self.context) {
+                // Console dropped while selected. We just replaced it with the
+                // default so there's nothing more to do.
+            } else {
+                // Console dropped while a different console was selected. Put back
+                // the console that was selected.
+                ctru_sys::consoleSelect(current_console);
+            }
+        }
+    }
+}

--- a/ctru-rs/src/console.rs
+++ b/ctru-rs/src/console.rs
@@ -54,6 +54,11 @@ impl Default for Console {
 impl Drop for Console {
     fn drop(&mut self) {
         unsafe {
+            // Safety: We are about to deallocate the PrintConsole data pointed
+            // to by libctru. Without this drop code libctru would have a
+            // dangling pointer that it writes to on every print. To prevent
+            // this we replace the console with the default if it was selected.
+
             // Get the current console by replacing it with the default.
             let default_console = ctru_sys::consoleGetDefault();
             let current_console = ctru_sys::consoleSelect(default_console);

--- a/ctru-rs/src/console.rs
+++ b/ctru-rs/src/console.rs
@@ -65,7 +65,10 @@ impl Drop for Console {
 
             if std::ptr::eq(current_console, &*self.context) {
                 // Console dropped while selected. We just replaced it with the
-                // default so there's nothing more to do.
+                // default so make sure it's initialized.
+                if !(*default_console).consoleInitialised {
+                    ctru_sys::consoleInit(Screen::Top.into(), default_console);
+                }
             } else {
                 // Console dropped while a different console was selected. Put back
                 // the console that was selected.


### PR DESCRIPTION
This is needed for soundness. Otherwise libctru will have a dangling pointer and will write to it when printing.

Closes #15 (I think, maybe we also need some panic changes before closing?)