### PR TITLE
Fix dropping Gfx before Console

### DIFF
--- a/ctru-rs/examples/buttons.rs
+++ b/ctru-rs/examples/buttons.rs
@@ -1,5 +1,5 @@
 use ctru::console::Console;
-use ctru::gfx::Gfx;
+use ctru::gfx::{Gfx, Screen};
 use ctru::services::apt::Apt;
 use ctru::services::hid::{Hid, KeyPad};
 
@@ -9,7 +9,7 @@ fn main() {
     let apt = Apt::init().unwrap();
     let hid = Hid::init().unwrap();
     let gfx = Gfx::default();
-    let console = Console::init(&gfx, ctru::gfx::Screen::Top);
+    let console = Console::init(&gfx, Screen::Top);
 
     println!("Hi there! Try pressing a button");
     println!("\x1b[29;16HPress Start to exit");

--- a/ctru-rs/examples/gfx_wide_mode.rs
+++ b/ctru-rs/examples/gfx_wide_mode.rs
@@ -11,7 +11,7 @@ fn main() {
     let apt = Apt::init().unwrap();
     let hid = Hid::init().unwrap();
     let gfx = Gfx::default();
-    let _console = Console::init(&gfx, ctru::gfx::Screen::Top);
+    let _console = Console::init(&gfx, Screen::Top);
 
     println!("Press A to enable/disable wide screen mode.");
 

--- a/ctru-rs/examples/hello-both-screens.rs
+++ b/ctru-rs/examples/hello-both-screens.rs
@@ -11,11 +11,11 @@ fn main() {
     let gfx = Gfx::default();
 
     // Start a console on the top screen
-    let top_screen = Console::init(&gfx, ctru::gfx::Screen::Top);
+    let top_screen = Console::init(&gfx, Screen::Top);
 
     // Start a console on the bottom screen.
     // The most recently initialized console will be active by default
-    let bottom_screen = Console::init(&gfx, ctru::gfx::Screen::Bottom);
+    let bottom_screen = Console::init(&gfx, Screen::Bottom);
 
     // Let's print on the top screen first
     top_screen.select();

--- a/ctru-rs/examples/hello-world.rs
+++ b/ctru-rs/examples/hello-world.rs
@@ -1,5 +1,5 @@
 use ctru::console::Console;
-use ctru::gfx::Gfx;
+use ctru::gfx::{Gfx, Screen};
 use ctru::services::apt::Apt;
 use ctru::services::hid::{Hid, KeyPad};
 
@@ -21,7 +21,7 @@ fn main() {
 
     // Initialize a ctrulib console and direct standard output to it.
     // Consoles can be initialized on both the top and bottom screens.
-    let _console = Console::init(&gfx, ctru::gfx::Screen::Top);
+    let _console = Console::init(&gfx, Screen::Top);
 
     // Now we can print to stdout!
     println!("Hello, world!");

--- a/ctru-rs/examples/software-keyboard.rs
+++ b/ctru-rs/examples/software-keyboard.rs
@@ -1,6 +1,6 @@
 use ctru::applets::swkbd::{Button, Swkbd};
 use ctru::console::Console;
-use ctru::gfx::Gfx;
+use ctru::gfx::{Gfx, Screen};
 use ctru::services::apt::Apt;
 use ctru::services::hid::{Hid, KeyPad};
 
@@ -9,7 +9,7 @@ fn main() {
     let apt = Apt::init().unwrap();
     let hid = Hid::init().unwrap();
     let gfx = Gfx::default();
-    let _console = Console::init(&gfx, ctru::gfx::Screen::Top);
+    let _console = Console::init(&gfx, Screen::Top);
 
     println!("Press A to enter some text or press Start to quit");
 


### PR DESCRIPTION
This prevents dropping the Gfx object before the console. We want to do this because printing after dropping gfx doesn't do anything (gfx isn't rendering the text anymore).

Note that even though Rust doesn't understand the relationship between Console and println, even if you don't use the console variable Rust will prevent Gfx dropping because Console's Drop code _might_ use the Gfx object (it doesn't, but we get the error we want anyway).

Also made importing in the examples more consistent.