### PR TITLE
Use a module for bindings instead of `include!`

### DIFF
--- a/ctru-sys/src/lib.rs
+++ b/ctru-sys/src/lib.rs
@@ -1,7 +1,9 @@
-#![allow(non_upper_case_globals)]
-#![allow(non_camel_case_types)]
-#![allow(non_snake_case)]
-#![allow(clippy::all)]
 #![no_std]
 
-include!("bindings.rs");
+#[allow(non_upper_case_globals)]
+#[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
+#[allow(clippy::all)]
+mod bindings;
+
+pub use bindings::*;


### PR DESCRIPTION
Modules are better understood by rust-analyzer compared to macro expansion, and we can still use the same bindgen script and lint attrs.

Before, "go to definition" would jump to the `include!()` call, but now it actually resolves to the `extern` declaration for functions, or the constant value for constants. I think this provides a better developer experience, since it more easily lets you find related functions, see constant values etc.

AFAIK, there is no functional difference between this and `include!()`, and I was able to build all the existing examples.