### PR TITLE
Update libc to the upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,2 @@
 [workspace]
 members = ["ctru-rs", "ctru-sys"]
-
-[patch.crates-io]
-# 3DS support hasn't merged into the upstream yet
-libc = { git = "https://github.com/Meziu/libc.git" }

--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -16,7 +16,7 @@ ctru-sys = { path = "../ctru-sys", version = "0.4" }
 const-zero = "0.1.0"
 linker-fix-3ds = { git = "https://github.com/Meziu/rust-linker-fix-3ds.git" }
 pthread-3ds = { git = "https://github.com/Meziu/pthread-3ds.git" }
-libc = "0.2"
+libc = "0.2.116"
 bitflags = "1.0.0"
 widestring = "0.2.2"
 

--- a/ctru-sys/Cargo.toml
+++ b/ctru-sys/Cargo.toml
@@ -7,4 +7,4 @@ links = "ctru"
 edition = "2021"
 
 [dependencies]
-libc = { version = "0.2", default-features = false }
+libc = { version = "0.2.116", default-features = false }


### PR DESCRIPTION
Our PR merged.

Depends on:
* https://github.com/Meziu/rust-horizon/pull/5
* https://github.com/Meziu/pthread-3ds/pull/4
* https://github.com/Meziu/rust-linker-fix-3ds/pull/7