### PR TITLE
Add translations of 3DS result macros + debug impl

### DIFF
--- a/ctru-rs/src/error.rs
+++ b/ctru-rs/src/error.rs
@@ -6,12 +6,13 @@ use ctru_sys::result::{R_DESCRIPTION, R_LEVEL, R_MODULE, R_SUMMARY};
 pub type Result<T> = ::std::result::Result<T, Error>;
 
 /// The error type returned by all libctru functions.
+#[non_exhaustive]
 pub enum Error {
-    Os(i32),
+    Os(ctru_sys::Result),
 }
 
-impl From<i32> for Error {
-    fn from(err: i32) -> Self {
+impl From<ctru_sys::Result> for Error {
+    fn from(err: ctru_sys::Result) -> Self {
         Error::Os(err)
     }
 }
@@ -19,15 +20,14 @@ impl From<i32> for Error {
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Os(err) => {
-                write!(f, "libctru result code: {:08X}:", err)?;
-                f.debug_struct("")
-                    .field("description", &R_DESCRIPTION(err))
-                    .field("module", &R_MODULE(err))
-                    .field("summary", &R_SUMMARY(err))
-                    .field("level", &R_LEVEL(err))
-                    .finish()
-            }
+            Error::Os(err) => f
+                .debug_struct("Error")
+                .field("raw", &format_args!("{:#08X}", err))
+                .field("description", &R_DESCRIPTION(err))
+                .field("module", &R_MODULE(err))
+                .field("summary", &R_SUMMARY(err))
+                .field("level", &R_LEVEL(err))
+                .finish(),
         }
     }
 }

--- a/ctru-rs/src/error.rs
+++ b/ctru-rs/src/error.rs
@@ -1,6 +1,8 @@
 use std::error;
 use std::fmt;
 
+use ctru_sys::result::{R_DESCRIPTION, R_LEVEL, R_MODULE, R_SUMMARY};
+
 pub type Result<T> = ::std::result::Result<T, Error>;
 
 /// The error type returned by all libctru functions.
@@ -17,12 +19,22 @@ impl From<i32> for Error {
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::Os(err) => write!(f, "libctru result code: {:08X}", err),
+            Error::Os(err) => {
+                write!(f, "libctru result code: {:08X}:", err)?;
+                f.debug_struct("")
+                    .field("description", &R_DESCRIPTION(err))
+                    .field("module", &R_MODULE(err))
+                    .field("summary", &R_SUMMARY(err))
+                    .field("level", &R_LEVEL(err))
+                    .finish()
+            }
         }
     }
 }
 
-// TODO: Expand libctru result code into human-readable error message
+// TODO: Expand libctru result code into human-readable error message. These should be useful:
+// https://www.3dbrew.org/wiki/Error_codes
+// https://github.com/devkitPro/libctru/blob/master/libctru/include/3ds/result.h
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {

--- a/ctru-sys/src/lib.rs
+++ b/ctru-sys/src/lib.rs
@@ -1,9 +1,12 @@
 #![no_std]
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(clippy::all)]
 
-#[allow(non_upper_case_globals)]
-#[allow(non_camel_case_types)]
-#[allow(non_snake_case)]
-#[allow(clippy::all)]
+pub mod result;
+
 mod bindings;
 
 pub use bindings::*;
+pub use result::*;

--- a/ctru-sys/src/result.rs
+++ b/ctru-sys/src/result.rs
@@ -1,0 +1,42 @@
+//! Ports of macros in
+//! <https://github.com/devkitPro/libctru/blob/master/libctru/include/3ds/result.h>
+
+use crate::Result;
+
+/// Checks whether a result code indicates success.
+pub fn R_SUCCEEDED(res: Result) -> bool {
+    res >= 0
+}
+
+/// Checks whether a result code indicates failure.
+pub fn R_FAILED(res: Result) -> bool {
+    res < 0
+}
+
+/// Returns the level of a result code.
+pub fn R_LEVEL(res: Result) -> Result {
+    (res >> 27) & 0x1F
+}
+
+/// Returns the summary of a result code.
+pub fn R_SUMMARY(res: Result) -> Result {
+    (res >> 21) & 0x3F
+}
+
+/// Returns the module ID of a result code.
+pub fn R_MODULE(res: Result) -> Result {
+    (res >> 10) & 0xFF
+}
+
+/// Returns the description of a result code.
+pub fn R_DESCRIPTION(res: Result) -> Result {
+    res & 0x3FF
+}
+
+/// Builds a result code from its constituent components.
+pub fn MAKERESULT(level: Result, summary: Result, module: Result, description: Result) -> Result {
+    ((level & 0x1F) << 27)
+        | ((summary & 0x3F) << 21)
+        | ((module & 0xFF) << 10)
+        | (description & 0x3FF)
+}


### PR DESCRIPTION
As @AzureMarker pointed out, we can use these to decode error return values from the libctru APIs. I also added a little more info to the `Debug` impl for `ctru_rs::Result` which should help debugging a bit in some cases.

See https://github.com/devkitPro/libctru/blob/master/libctru/include/3ds/result.h for the original definitions, which I assume are not generated by `bindgen` since they are macros and not simple `#define`s.

I intend to use these in https://github.com/Meziu/rust-linker-fix-3ds/pull/8 to translate from libctru codes to `errno` values, and make the `getrandom` behavior closer to spec.