### PR TITLE
Remove duplicate dependencies by patching, and add back links field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,10 @@
 [workspace]
 members = ["ctru-rs", "ctru-sys"]
+
+[patch.crates-io]
+# We have some changes not in the upstream
+libc = { git = "https://github.com/Meziu/libc.git" }
+
+[patch.'https://github.com/Meziu/ctru-rs']
+# Make sure all dependencies use the local ctru-sys package
+ctru-sys = { path = "ctru-sys" }

--- a/ctru-sys/Cargo.toml
+++ b/ctru-sys/Cargo.toml
@@ -3,6 +3,7 @@ name = "ctru-sys"
 version = "0.4.0"
 authors = ["Ronald Kinard <furyhunter600@gmail.com>"]
 license = "https://en.wikipedia.org/wiki/Zlib_License"
+links = "ctru"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
We don't want duplicate ctru-sys crates in the dependency graph. Same for libc. We can patch them here to avoid any issues.

Now that we don't have duplicate ctru-sys crates, we can add back the links field. This field is important because it warns us when there are two crates linking to the same library (ex. duplicate ctru-sys crates). I think there's some misconceptions about how the `links` field works, so here's its docs and some clarifications:
https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key
The `links` field does not automatically link the crate to the library. Instead it's more of a hint to Cargo that this crate should link to that native library. Cargo then enforces some things, like having a build script and only having one crate which links to this library in the dependency graph. These are useful things to enforce.

Downstream crates don't need the ctru-sys patch, so it's only an issue here (they could add the patch for libc, but it's not required). I verified this with my project: https://github.com/AzureMarker/n3ds-controller/commit/e16453cebaf114cdadf085ad21a8036834db8d19