### PR TITLE
Update libc to 0.2.121 (upstream)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,8 @@
 [workspace]
 members = ["ctru-rs", "ctru-sys"]
 
-[patch.crates-io]
-# We have some changes not in the upstream
-libc = { git = "https://github.com/Meziu/libc.git" }
+[patch.'https://github.com/Meziu/libc']
+libc = "0.2.121"
 
 [patch.'https://github.com/Meziu/ctru-rs']
 # Make sure all dependencies use the local ctru-sys package

--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -16,7 +16,7 @@ ctru-sys = { path = "../ctru-sys", version = "0.4" }
 const-zero = "0.1.0"
 linker-fix-3ds = { git = "https://github.com/Meziu/rust-linker-fix-3ds.git" }
 pthread-3ds = { git = "https://github.com/Meziu/pthread-3ds.git" }
-libc = "0.2.116"
+libc = "0.2.121"
 bitflags = "1.0.0"
 widestring = "0.2.2"
 once_cell = "1.10.0"

--- a/ctru-sys/Cargo.toml
+++ b/ctru-sys/Cargo.toml
@@ -7,4 +7,4 @@ links = "ctru"
 edition = "2021"
 
 [dependencies]
-libc = { version = "0.2.116", default-features = false }
+libc = { version = "0.2.121", default-features = false }


### PR DESCRIPTION
All of our 3DS changes have been upstreamed. If in the future we need to use the fork again, we can edit the top-level Cargo.toml and adjust the patches (replace upstream with fork).

The rust-horizon fork (mine at least) also uses 0.2.121.