### PR TITLE
Add failing example with regex

### DIFF
--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -30,6 +30,7 @@ futures = "0.3"
 time = "0.3.7"
 tokio = { version = "1.16", features = ["rt", "time", "sync", "macros"] }
 cfg-if = "1.0.0"
+regex = "1.5.5"
 
 [features]
 default = ["romfs"]

--- a/ctru-rs/examples/regex.rs
+++ b/ctru-rs/examples/regex.rs
@@ -1,0 +1,41 @@
+use ctru::console::Console;
+use ctru::gfx::Gfx;
+use ctru::services::apt::Apt;
+use ctru::services::hid::{Hid, KeyPad};
+
+use regex::Regex;
+
+fn main() {
+    ctru::init();
+    let gfx = Gfx::init().expect("Couldn't obtain GFX controller");
+    let _console = Console::init(gfx.bottom_screen.borrow_mut());
+
+    let re = Regex::new(r"(?P<key>.+)=(?P<value>.+)").unwrap();
+
+    for m in ["K1=V1", "no match", "X=Y"] {
+        if let Some(m) = re.captures(m) {
+            println!(
+                "Key = {key:?}, value = {value:?}",
+                key = m.name("key"),
+                value = m.name("value")
+            );
+        }
+    }
+
+    let hid = Hid::init().expect("Couldn't obtain HID controller");
+    let apt = Apt::init().expect("Couldn't obtain APT controller");
+    while apt.main_loop() {
+        //Scan all the inputs. This should be done once for each frame
+        hid.scan_input();
+
+        if hid.keys_down().contains(KeyPad::KEY_START) {
+            break;
+        }
+        // Flush and swap framebuffers
+        gfx.flush_buffers();
+        gfx.swap_buffers();
+
+        // Wait for VBlank
+        gfx.wait_for_vblank();
+    }
+}


### PR DESCRIPTION
Hey @AzureMarker and @Meziu !

I found a strange example that I can reliably reproduce a segfault with seemingly safe code, and I'm wondering if you have any ideas to help debug it as I've gotten a bit stuck.

Running gdb attached to a device I get this as the location of the crash: https://github.com/rust-lang/regex/blob/master/src/exec.rs#L299

<details>
<summary>GDB backtrace</summary>

```
(gdb) bt full 
#0  0x00148980 in regex::exec::ExecBuilder::build (self=...)
    at /Users/ianchamberlain/.cargo/registry/src/github.com-1ecc6299db9ec823/regex-1.5.5/src/exec.rs:299
No locals.
#1  0x0013dc98 in regex::re_builder::unicode::RegexBuilder::build (self=0x8007bc8)
    at /Users/ianchamberlain/.cargo/registry/src/github.com-1ecc6299db9ec823/regex-1.5.5/src/re_builder.rs:70
No locals.
#2  0x001948c0 in regex::re_unicode::Regex::new (re=...)
    at /Users/ianchamberlain/.cargo/registry/src/github.com-1ecc6299db9ec823/regex-1.5.5/src/re_unicode.rs:175
No locals.
#3  0x00100728 in regex::main () at ctru-rs/examples/regex.rs:13
        _console = ctru::console::Console {context: 0x800c8b0, _screen: core::cell::RefMut<dyn ctru::gfx::Screen> {value: &mut dyn ctru::gfx::Screen {pointer: 0x8007c5c, vtable: 0x3a7068}, borrow: core::cell::BorrowRefMut {borrow: 0x8007c58}}}
        gfx = ctru::gfx::Gfx {top_screen: core::cell::RefCell<ctru::gfx::TopScreen> {borrow: core::cell::Cell<isize> {value: core::cell::UnsafeCell<isize> {value: 0}}, value: core::cell::UnsafeCell<ctru::gfx::TopScreen> {value: ctru::gfx::TopScreen}}, bottom_screen: core::cell::RefCell<ctru::gfx::BottomScreen> {borrow: core::cell::Cell<isize> {value: core::cell::UnsafeCell<isize> {value: -1}}, value: core::cell::UnsafeCell<ctru::gfx::BottomScreen> {value: ctru::gfx::BottomScreen}}, _service_handler: ctru::services::reference::ServiceReference {counter: 0x442018 <ctru::gfx::GFX_ACTIVE+4>, close: alloc::boxed::Box<(dyn core::ops::function::Fn<(), Output=()> + core::marker::Send + core::marker::Sync), alloc::alloc::Global> {pointer: 0x1, vtable: 0x3fc06c}}}
```
</details>

The `self` pointer seems to be optimized out at the call site, so I'm wondering what kind of address violation might be happening here... perhaps UB introduced by some call before the regex builder?

Let me know if you have any ideas or suggestions for tracking down this kind of issue. I couldn't find any references to issues like this upstream, etc. so I'm a bit stumped.

----

Edit: Note, I'm using a rebased version of `feature/horizon-threads` onto latest upstream master, but it seemed to reproduce on a different toolchain version I had as well. Going to to try and rebuild my toolchain again to see if it makes any difference, in case this is a miscompilation kind of thing...