### PR TITLE
Initial attempt at CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+env:
+  # https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html
+  CARGO_UNSTABLE_SPARSE_REGISTRY: "true"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    container: devkitpro/devkitarm
+    steps:
+      - if: ${{ env.ACT }}
+        name: Hack container for local development
+        run: |
+            curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+            sudo apt-get install -y nodejs
+
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - name: Setup default Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          components: clippy, rustfmt, rust-src
+          profile: minimal
+          toolchain: nightly
+          default: true
+
+      - name: Install build tools for host
+        run: sudo apt-get install -y build-essential
+
+      - name: Install cargo-3ds
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          # TODO: this should probably just be a released version from crates.io
+          # once cargo-3ds gets published somewhere...
+          args: >-
+            --git https://github.com/rust3ds/cargo-3ds
+            --rev 913645665391ea715bc96910bda35f98a4536a6e
+
+      - name: Check formatting
+        run: cargo fmt --all --verbose -- --check
+
+      # For some reason, `cargo clippy` doesn't seem to work properly with
+      # -Zbuild-std (and thus with `cargo 3ds`). Maybe would be helped by
+      # https://github.com/rust3ds/cargo-3ds/pull/21 ?
+      - name: Cargo check
+        run: cargo 3ds check --color=always --workspace --verbose --all-targets
+        env:
+          RUSTFLAGS:
+            --deny=warnings
+
+  # TODO: it would be nice to actually build 3dsx for examples/tests, etc.
+  # and run it somehow, but exactly how remains to be seen. Also, we probably
+  # need the std::thread PR to land before a lot of the examples are runnable.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,15 @@ env:
 
 jobs:
   lint:
+    strategy:
+      matrix:
+        toolchain:
+          # Run against a "known good" nightly
+          - nightly-2022-07-18
+          # Check for breakage on latest nightly
+          - nightly
+    # But if latest nightly fails, allow the workflow to continue
+    continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     runs-on: ubuntu-latest
     container: devkitpro/devkitarm
     steps:
@@ -25,7 +34,7 @@ jobs:
         with:
           components: clippy, rustfmt, rust-src
           profile: minimal
-          toolchain: nightly
+          toolchain: ${{ matrix.toolchain }}
           default: true
 
       - name: Install build tools for host
@@ -39,20 +48,16 @@ jobs:
           # once cargo-3ds gets published somewhere...
           args: >-
             --git https://github.com/rust3ds/cargo-3ds
-            --rev 913645665391ea715bc96910bda35f98a4536a6e
+            --rev 7b70b6b26c4740b9a10ab85b832ee73c41142bbb
 
       - name: Check formatting
         run: cargo fmt --all --verbose -- --check
 
-      # For some reason, `cargo clippy` doesn't seem to work properly with
-      # -Zbuild-std (and thus with `cargo 3ds`). Maybe would be helped by
-      # https://github.com/rust3ds/cargo-3ds/pull/21 ?
       - name: Cargo check
-        run: cargo 3ds check --color=always --workspace --verbose --all-targets
+        run: cargo 3ds clippy --color=always --workspace --verbose --all-targets
         env:
           RUSTFLAGS:
             --deny=warnings
 
   # TODO: it would be nice to actually build 3dsx for examples/tests, etc.
-  # and run it somehow, but exactly how remains to be seen. Also, we probably
-  # need the std::thread PR to land before a lot of the examples are runnable.
+  # and run it somehow, but exactly how remains to be seen.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 env:
   # https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     container: devkitpro/devkitarm
     steps:
-      - if: ${{ env.ACT }}
-        name: Hack container for local development
-        run: |
-            curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
-            sudo apt-get install -y nodejs
-
       - name: Checkout branch
         uses: actions/checkout@v2
 

--- a/ctru-rs/Cargo.toml
+++ b/ctru-rs/Cargo.toml
@@ -36,5 +36,29 @@ default = ["romfs", "big-stack"]
 romfs = []
 big-stack = []
 
+# Temporary feature to disable some examples by default,
+# until thread support is upstreamed
+std-threads = []
+
 [package.metadata.cargo-3ds]
 romfs_dir = "examples/romfs"
+
+[[example]]
+name = "thread-basic"
+required-features = ["std-threads"]
+
+[[example]]
+name = "thread-info"
+required-features = ["std-threads"]
+
+[[example]]
+name = "thread-locals"
+required-features = ["std-threads"]
+
+[[example]]
+name = "futures-basic"
+required-features = ["std-threads"]
+
+[[example]]
+name = "futures-tokio"
+required-features = ["std-threads"]

--- a/ctru-rs/examples/network-sockets.rs
+++ b/ctru-rs/examples/network-sockets.rs
@@ -43,7 +43,7 @@ fn main() {
                         } else {
                             println!("Unable to read stream: {}", e)
                         }
-                    },
+                    }
                 }
 
                 let response = b"HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n<html><body>Hello world</body></html>\r\n";

--- a/ctru-rs/src/services/reference.rs
+++ b/ctru-rs/src/services/reference.rs
@@ -16,7 +16,9 @@ impl ServiceReference {
         S: FnOnce() -> crate::Result<()>,
         E: Fn() + Send + Sync + 'static,
     {
-        let mut value = counter.lock().expect("Mutex Counter for ServiceReference is poisoned"); // todo: handle poisoning
+        let mut value = counter
+            .lock()
+            .expect("Mutex Counter for ServiceReference is poisoned"); // todo: handle poisoning
 
         if *value == 0 {
             start()?;
@@ -35,7 +37,10 @@ impl ServiceReference {
 
 impl Drop for ServiceReference {
     fn drop(&mut self) {
-        let mut value = self.counter.lock().expect("Mutex Counter for ServiceReference is poisoned"); // todo: handle poisoning
+        let mut value = self
+            .counter
+            .lock()
+            .expect("Mutex Counter for ServiceReference is poisoned"); // todo: handle poisoning
         *value -= 1;
         if *value == 0 {
             (self.close)();

--- a/ctru-sys/src/bin/docstring-to-rustdoc.rs
+++ b/ctru-sys/src/bin/docstring-to-rustdoc.rs
@@ -19,8 +19,8 @@
 //! The followings are _partially_ transformed to Rustdoc format:
 //! * `@param`
 
-use std::{env, fs, io};
 use std::path::Path;
+use std::{env, fs, io};
 
 fn main() -> io::Result<()> {
     let args: Vec<String> = env::args().collect();
@@ -33,8 +33,7 @@ fn main() -> io::Result<()> {
         .map(|v| {
             // Only modify lines with the following structure: `` #[doc ... ] ``
             if v.trim_start().starts_with("#[doc") && v.trim_end().ends_with("]") {
-                v
-                    .replace("@brief", "")
+                v.replace("@brief", "")
                     // Example: ``@param offset Offset of the RomFS...`` -> ``- offset Offset of the RomFS...``
                     // Will improve in the future
                     .replace("@param", "* ")
@@ -54,9 +53,7 @@ fn main() -> io::Result<()> {
                 String::from(v)
             }
         })
-        .map(|v| {
-            v + "\n"
-        })
+        .map(|v| v + "\n")
         .collect::<String>();
 
     let old_bindings_path = bindings_path.to_str().unwrap().to_owned() + ".old";

--- a/ctru-sys/src/bin/docstring-to-rustdoc.rs
+++ b/ctru-sys/src/bin/docstring-to-rustdoc.rs
@@ -32,7 +32,7 @@ fn main() -> io::Result<()> {
         .lines()
         .map(|v| {
             // Only modify lines with the following structure: `` #[doc ... ] ``
-            if v.trim_start().starts_with("#[doc") && v.trim_end().ends_with("]") {
+            if v.trim_start().starts_with("#[doc") && v.trim_end().ends_with(']') {
                 v.replace("@brief", "")
                     // Example: ``@param offset Offset of the RomFS...`` -> ``- offset Offset of the RomFS...``
                     // Will improve in the future


### PR DESCRIPTION
Since this project is starting to attract a few more people, I thought it would be a good idea to introduce some basic CI (even if we can't run e.g. unit tests, examples).

This relies on the std PR being merged, and unfortunately is broken since the `std::thread` PR hasn't been merged yet, but we could either `#[cfg]` out the broken example, or just wait on this until there is a new nightly that has been built with `std::thread`.

Either way, I thought I'd put up the PR to show a starting point, and also to see if I could test an actual actions run. @Meziu it might require you to allow Actions runs in order to test this, since there haven't been any up until now.