### PR TITLE
Fix CI by running apt-get update before install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           default: true
 
       - name: Install build tools for host
-        run: sudo apt-get install -y build-essential
+        run: sudo apt-get update && sudo apt-get install -y build-essential
 
       - name: Install cargo-3ds
         uses: actions-rs/cargo@v1

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -90,7 +90,7 @@ impl Swkbd {
     /// (from 1-3).
     pub fn init(keyboard_type: Kind, num_buttons: i32) -> Self {
         unsafe {
-            let mut state = Box::new(SwkbdState::default());
+            let mut state = Box::default();
             swkbdInit(state.as_mut(), keyboard_type as u32, num_buttons, -1);
             Swkbd { state }
         }

--- a/ctru-rs/src/applets/swkbd.rs
+++ b/ctru-rs/src/applets/swkbd.rs
@@ -90,7 +90,7 @@ impl Swkbd {
     /// (from 1-3).
     pub fn init(keyboard_type: Kind, num_buttons: i32) -> Self {
         unsafe {
-            let mut state = Box::default();
+            let mut state = Box::<SwkbdState>::default();
             swkbdInit(state.as_mut(), keyboard_type as u32, num_buttons, -1);
             Swkbd { state }
         }

--- a/ctru-rs/src/console.rs
+++ b/ctru-rs/src/console.rs
@@ -17,7 +17,7 @@ impl<'screen> Console<'screen> {
     /// previously (including other consoles). The new console is automatically selected for
     /// printing.
     pub fn init(screen: RefMut<'screen, dyn Screen>) -> Self {
-        let mut context = Box::default();
+        let mut context = Box::<PrintConsole>::default();
 
         unsafe { consoleInit(screen.as_raw(), context.as_mut()) };
 

--- a/ctru-rs/src/console.rs
+++ b/ctru-rs/src/console.rs
@@ -17,7 +17,7 @@ impl<'screen> Console<'screen> {
     /// previously (including other consoles). The new console is automatically selected for
     /// printing.
     pub fn init(screen: RefMut<'screen, dyn Screen>) -> Self {
-        let mut context = Box::new(PrintConsole::default());
+        let mut context = Box::default();
 
         unsafe { consoleInit(screen.as_raw(), context.as_mut()) };
 


### PR DESCRIPTION
The apt package cache was out of date, causing failures. Example:
https://github.com/Meziu/ctru-rs/actions/runs/3186950814/jobs/5250099350

Also fixed a new clippy lint warning.